### PR TITLE
Fix newlines being saved as a valid command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,7 +128,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -220,6 +229,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +247,12 @@ dependencies = [
  "nix",
  "winapi",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "directories"
@@ -400,12 +425,14 @@ dependencies = [
  "hostname",
  "humantime 2.1.0",
  "log",
+ "pretty_assertions",
  "pretty_env_logger",
  "regex",
  "rusqlite",
  "serde",
  "sled",
  "structopt",
+ "tempfile",
  "thiserror",
  "toml",
  "uuid",
@@ -591,6 +618,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +676,24 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
+dependencies = [
+ "ansi_term 0.12.1",
+ "ctor",
+ "diff",
+ "output_vt100",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -700,6 +754,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +834,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rusqlite"
@@ -906,6 +1009,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ thiserror = "1"
 toml = "0.5"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
+[dev-dependencies]
+tempfile = "3"
+pretty_assertions = "1"
+
 [profile.release]
 lto = "fat"
 panic = "abort"

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -27,8 +27,6 @@ pub struct Entry {
 
 impl Entry {
     pub fn from_messages(start: CommandStart, finish: &CommandFinished) -> Self {
-        dbg!(&start.command);
-
         let command = start.command.trim_end();
 
         let command = command
@@ -39,8 +37,6 @@ impl Entry {
 
         let user = start.user.trim().to_string();
         let hostname = start.hostname.trim().to_string();
-
-        dbg!(&command);
 
         Self {
             time_finished: finish.time_stamp,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -27,15 +27,30 @@ pub struct Entry {
 
 impl Entry {
     pub fn from_messages(start: CommandStart, finish: &CommandFinished) -> Self {
+        dbg!(&start.command);
+
+        let command = start.command.trim_end();
+
+        let command = command
+            .strip_suffix("\\r\\n")
+            .or_else(|| command.strip_suffix("\\n"))
+            .unwrap_or(command)
+            .to_string();
+
+        let user = start.user.trim().to_string();
+        let hostname = start.hostname.trim().to_string();
+
+        dbg!(&command);
+
         Self {
-            command: start.command,
+            time_finished: finish.time_stamp,
+            time_start: start.time_stamp,
+            hostname,
+            command,
             pwd: start.pwd,
             result: finish.result,
             session_id: start.session_id,
-            time_finished: finish.time_stamp,
-            time_start: start.time_stamp,
-            user: start.user,
-            hostname: start.hostname,
+            user,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod client;
+pub mod config;
+pub mod entry;
+pub mod message;
+pub mod opt;
+pub mod run;
+pub mod server;
+pub mod store;

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -301,7 +301,7 @@ pub fn zsh_add_history(
 }
 
 pub fn server(cache_dir: PathBuf, socket: PathBuf, data_dir: PathBuf) -> Result<(), Error> {
-    server::builder(cache_dir, data_dir, socket)
+    server::builder(cache_dir, data_dir, socket, true)
         .build()?
         .run()?;
 

--- a/src/server/builder.rs
+++ b/src/server/builder.rs
@@ -33,6 +33,7 @@ pub struct Builder {
     pub(super) cache_dir: PathBuf,
     pub(super) data_dir: PathBuf,
     pub(super) socket: PathBuf,
+    pub(super) handle_ctrlc: bool,
 }
 
 impl Builder {
@@ -48,6 +49,8 @@ impl Builder {
         let stopping = Arc::new(AtomicBool::new(false));
         let wait_group = WaitGroup::new();
 
+        let handle_ctrlc = self.handle_ctrlc;
+
         Ok(Server {
             db,
             socket,
@@ -55,6 +58,7 @@ impl Builder {
             store,
             stopping,
             wait_group,
+            handle_ctrlc,
         })
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -101,13 +101,20 @@ pub struct Server {
     pub(super) store: Store,
     pub(super) stopping: Arc<AtomicBool>,
     pub(super) wait_group: WaitGroup,
+    pub(super) handle_ctrlc: bool,
 }
 
-pub fn builder(cache_dir: PathBuf, data_dir: PathBuf, socket: PathBuf) -> Builder {
+pub fn builder(
+    cache_dir: PathBuf,
+    data_dir: PathBuf,
+    socket: PathBuf,
+    handle_ctrlc: bool,
+) -> Builder {
     Builder {
         cache_dir,
         data_dir,
         socket,
+        handle_ctrlc,
     }
 }
 
@@ -128,7 +135,9 @@ impl Server {
             data_sender,
         );
 
-        Self::ctrl_c_watcher(self.stopping, self.socket_path.clone())?;
+        if self.handle_ctrlc {
+            Self::ctrl_c_watcher(self.stopping, self.socket_path.clone())?;
+        }
 
         info!("listening on {:?}", self.socket_path);
 

--- a/tests/client_server_intigration.rs
+++ b/tests/client_server_intigration.rs
@@ -1,0 +1,376 @@
+use pretty_assertions::assert_eq;
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc,
+        Barrier,
+    },
+    thread,
+};
+
+use chrono::Utc;
+use hstdb::{
+    client::{
+        self,
+        Client,
+    },
+    entry::Entry,
+    message::{
+        CommandFinished,
+        CommandStart,
+        Message,
+    },
+    server,
+    store::{
+        self,
+        Filter,
+    },
+};
+use uuid::Uuid;
+
+struct TestClient {
+    client: Client,
+    barrier_stop: Arc<Barrier>,
+    cache_dir: PathBuf,
+    data_dir: PathBuf,
+
+    keep_datadir: bool,
+}
+
+impl Drop for TestClient {
+    fn drop(&mut self) {
+        self.barrier_stop.wait();
+
+        std::fs::remove_dir_all(&self.cache_dir).unwrap();
+
+        if !self.keep_datadir {
+            std::fs::remove_dir_all(&self.data_dir).unwrap();
+        }
+    }
+}
+
+fn create_client_and_server(keep_datadir: bool) -> TestClient {
+    let cache_dir = tempfile::tempdir().unwrap().into_path();
+    let data_dir = tempfile::tempdir().unwrap().into_path();
+    let socket = tempfile::NamedTempFile::new()
+        .unwrap()
+        .into_temp_path()
+        .to_path_buf();
+
+    let barrier_start = Arc::new(Barrier::new(2));
+    let barrier_stop = Arc::new(Barrier::new(2));
+
+    {
+        let barrier_start = Arc::clone(&barrier_start);
+        let barrier_stop = Arc::clone(&barrier_stop);
+
+        let cache_dir = cache_dir.clone();
+        let data_dir = data_dir.clone();
+        let socket = socket.clone();
+
+        let server = server::builder(cache_dir, data_dir, socket, false)
+            .build()
+            .unwrap();
+
+        thread::spawn(move || {
+            barrier_start.wait();
+            server.run().unwrap();
+            barrier_stop.wait();
+        });
+    }
+
+    barrier_start.wait();
+
+    let client = client::new(socket);
+
+    TestClient {
+        client,
+        barrier_stop,
+        cache_dir,
+        data_dir,
+        keep_datadir,
+    }
+}
+
+#[test]
+fn stop_server() {
+    let client = create_client_and_server(false);
+    client.client.send(&Message::Stop).unwrap();
+}
+
+#[test]
+fn write_entry() {
+    let client = create_client_and_server(true);
+
+    let session_id = Uuid::new_v4();
+
+    let start_data = CommandStart {
+        command: "Test".to_string(),
+        pwd: PathBuf::from("/tmp"),
+        session_id: session_id.clone(),
+        time_stamp: Utc::now(),
+        user: "testuser".to_string(),
+        hostname: "testhostname".to_string(),
+    };
+
+    let finish_data = CommandFinished {
+        session_id,
+        time_stamp: Utc::now(),
+        result: 0,
+    };
+
+    client
+        .client
+        .send(&Message::CommandStart(start_data.clone()))
+        .unwrap();
+
+    client
+        .client
+        .send(&Message::CommandFinished(finish_data.clone()))
+        .unwrap();
+
+    client.client.send(&Message::Stop).unwrap();
+
+    let data_dir = client.data_dir.clone();
+    drop(client);
+
+    let mut entries = store::new(data_dir.clone())
+        .get_entries(&Filter::default())
+        .unwrap();
+
+    std::fs::remove_dir_all(data_dir).unwrap();
+
+    dbg!(&entries);
+
+    assert_eq!(entries.len(), 1);
+
+    let got = entries.remove(0);
+    let expected = Entry {
+        time_finished: finish_data.time_stamp,
+        time_start: start_data.time_stamp,
+        hostname: start_data.hostname,
+        command: start_data.command,
+        pwd: start_data.pwd,
+        result: finish_data.result,
+        session_id: start_data.session_id,
+        user: start_data.user,
+    };
+
+    assert_eq!(expected, got);
+}
+
+#[test]
+fn write_entry_whitespace() {
+    let client = create_client_and_server(true);
+
+    let session_id = Uuid::new_v4();
+
+    let start_data = CommandStart {
+        command: r#"Test\nTest\nTest      "#.to_string(),
+        pwd: PathBuf::from("/tmp"),
+        session_id: session_id.clone(),
+        time_stamp: Utc::now(),
+        user: "testuser".to_string(),
+        hostname: "testhostname".to_string(),
+    };
+
+    let finish_data = CommandFinished {
+        session_id,
+        time_stamp: Utc::now(),
+        result: 0,
+    };
+
+    client
+        .client
+        .send(&Message::CommandStart(start_data.clone()))
+        .unwrap();
+
+    client
+        .client
+        .send(&Message::CommandFinished(finish_data.clone()))
+        .unwrap();
+
+    client.client.send(&Message::Stop).unwrap();
+
+    let data_dir = client.data_dir.clone();
+    drop(client);
+
+    let mut entries = store::new(data_dir.clone())
+        .get_entries(&Filter::default())
+        .unwrap();
+
+    std::fs::remove_dir_all(data_dir).unwrap();
+
+    dbg!(&entries);
+
+    assert_eq!(entries.len(), 1);
+
+    let got = entries.remove(0);
+    let expected = Entry {
+        time_finished: finish_data.time_stamp,
+        time_start: start_data.time_stamp,
+        hostname: start_data.hostname,
+        command: r#"Test\nTest\nTest"#.to_string(),
+        pwd: start_data.pwd,
+        result: finish_data.result,
+        session_id: start_data.session_id,
+        user: start_data.user,
+    };
+
+    assert_eq!(expected, got);
+}
+
+// TODO: Make a test for this probably needs a restructuring of how we
+// detect leading spaces in commands
+//#[test]
+// fn write_command_starting_spaces() {
+//    let client = create_client_and_server(true);
+//
+//    let session_id = Uuid::new_v4();
+//
+//    let start_data = CommandStart {
+//        command: " Test".to_string(),
+//        pwd: PathBuf::from("/tmp"),
+//        session_id: session_id.clone(),
+//        time_stamp: Utc::now(),
+//        user: "testuser".to_string(),
+//        hostname: "testhostname".to_string(),
+//    };
+//
+//    let finish_data = CommandFinished {
+//        session_id,
+//        time_stamp: Utc::now(),
+//        result: 0,
+//    };
+//
+//    client
+//        .client
+//        .send(&Message::CommandStart(start_data.clone()))
+//        .unwrap();
+//
+//    client
+//        .client
+//        .send(&Message::CommandFinished(finish_data.clone()))
+//        .unwrap();
+//
+//    client.client.send(&Message::Stop).unwrap();
+//
+//    let data_dir = client.data_dir.clone();
+//    drop(client);
+//
+//    let entries = store::new(data_dir.clone())
+//        .get_entries(&Filter::default())
+//        .unwrap();
+//
+//    std::fs::remove_dir_all(data_dir).unwrap();
+//
+//    dbg!(&entries);
+//
+//    assert_eq!(entries.len(), 0);
+//}
+
+#[test]
+fn write_empty_command() {
+    let client = create_client_and_server(true);
+
+    let session_id = Uuid::new_v4();
+
+    let start_data = CommandStart {
+        command: "".to_string(),
+        pwd: PathBuf::from("/tmp"),
+        session_id: session_id.clone(),
+        time_stamp: Utc::now(),
+        user: "testuser".to_string(),
+        hostname: "testhostname".to_string(),
+    };
+
+    let finish_data = CommandFinished {
+        session_id,
+        time_stamp: Utc::now(),
+        result: 0,
+    };
+
+    client
+        .client
+        .send(&Message::CommandStart(start_data.clone()))
+        .unwrap();
+
+    client
+        .client
+        .send(&Message::CommandFinished(finish_data.clone()))
+        .unwrap();
+
+    client.client.send(&Message::Stop).unwrap();
+
+    let data_dir = client.data_dir.clone();
+    drop(client);
+
+    let entries = store::new(data_dir.clone())
+        .get_entries(&Filter::default())
+        .unwrap();
+
+    std::fs::remove_dir_all(data_dir).unwrap();
+
+    dbg!(&entries);
+
+    assert_eq!(entries.len(), 0);
+}
+
+#[test]
+fn write_newline_command() {
+    let client = create_client_and_server(true);
+
+    let session_id = Uuid::new_v4();
+
+    let commands = vec![
+        "\n".to_string(),
+        "\r\n".to_string(),
+        "\n\n".to_string(),
+        "\n\n\n".to_string(),
+        r#"\n"#.to_string(),
+        '\n'.to_string(),
+        '\r'.to_string(),
+    ];
+
+    for command in commands {
+        let start_data = CommandStart {
+            command,
+            pwd: PathBuf::from("/tmp"),
+            session_id: session_id.clone(),
+            time_stamp: Utc::now(),
+            user: "testuser".to_string(),
+            hostname: "testhostname".to_string(),
+        };
+
+        let finish_data = CommandFinished {
+            session_id,
+            time_stamp: Utc::now(),
+            result: 0,
+        };
+
+        client
+            .client
+            .send(&Message::CommandStart(start_data.clone()))
+            .unwrap();
+
+        client
+            .client
+            .send(&Message::CommandFinished(finish_data.clone()))
+            .unwrap();
+    }
+
+    client.client.send(&Message::Stop).unwrap();
+
+    let data_dir = client.data_dir.clone();
+    drop(client);
+
+    let entries = store::new(data_dir.clone())
+        .get_entries(&Filter::default())
+        .unwrap();
+
+    std::fs::remove_dir_all(data_dir).unwrap();
+
+    dbg!(&entries);
+
+    assert_eq!(entries.len(), 0);
+}


### PR DESCRIPTION
When a command was received that only contained newlines it was saved as
a valid command.

This pull-requests changes that and strips ending newlines (\n and \r\n)
from the command. When that results in an empty string the command will
not be saved like any other empty command.

Also added some integration tests for the client/server.

Fixes #21.