### PR TITLE
Replace outdated pretty_env_logger with env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,14 +295,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
- "humantime 1.3.0",
  "log",
- "regex",
  "termcolor",
 ]
 
@@ -459,14 +456,14 @@ dependencies = [
  "csv",
  "ctrlc",
  "directories",
+ "env_logger",
  "exitcode",
  "flume",
  "glob",
  "hostname",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "pretty_assertions",
- "pretty_env_logger",
  "regex",
  "rusqlite",
  "serde",
@@ -475,15 +472,6 @@ dependencies = [
  "thiserror",
  "toml",
  "uuid",
-]
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
 ]
 
 [[package]]
@@ -534,9 +522,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -748,16 +736,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,12 +767,6 @@ checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ glob = "0.3"
 hostname = "0.3"
 humantime = "2"
 log = { version = "0.4", features = ["serde"] }
-pretty_env_logger = "0.4"
+env_logger = { version = "0.10.0", default-features = false, features = ["color"] }
 regex = "1"
 rusqlite = { version = "0.27", optional = true }
 serde = { version = "1", features = ["derive"] }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -356,7 +356,7 @@ impl Opt {
         if std::env::var_os("RUST_LOG").is_none() {
             std::env::set_var("RUST_LOG", config.log_level.as_str());
         }
-        pretty_env_logger::init();
+        env_logger::init();
 
         sub_command.map_or_else(
             || {


### PR DESCRIPTION
pretty_env_logger hasn't been updated for 3 years and it pulls outdated version of env_logger.